### PR TITLE
Get tests running again

### DIFF
--- a/newark.gemspec
+++ b/newark.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'multi_json'
+  spec.add_development_dependency 'minitest', '~> 4.2'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,6 +6,6 @@ require 'newark'
 require 'rack/test'
 require 'minitest/autorun'
 
-class Minitest::Test
+class MiniTest::Unit::TestCase
 
 end

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -24,7 +24,7 @@ class NameApp
   end
 end
 
-class TestApp < Minitest::Test
+class TestApp < MiniTest::Unit::TestCase
 
   include Rack::Test::Methods
 

--- a/test/test_request.rb
+++ b/test/test_request.rb
@@ -20,7 +20,7 @@ class RequestApp
   end
 end
 
-class TestRequest < Minitest::Test
+class TestRequest < MiniTest::Unit::TestCase
 
   include Rack::Test::Methods
 

--- a/test/test_response.rb
+++ b/test/test_response.rb
@@ -9,7 +9,7 @@ class ResponseApp
   end
 end
 
-class TestResponse < Minitest::Test
+class TestResponse < MiniTest::Unit::TestCase
 
   include Rack::Test::Methods
 

--- a/test/test_router.rb
+++ b/test/test_router.rb
@@ -62,7 +62,7 @@ class TestingApp
 
 end
 
-class TestRouter < Minitest::Test
+class TestRouter < MiniTest::Unit::TestCase
 
   include Rack::Test::Methods
 


### PR DESCRIPTION
ActiveSupport pulls in an earlier Minitest version that requires different class naming. This adds the minitest version to the gemspec and updates to the older minitest-style.
