### PR TITLE
Use Newark Application class variables directly

### DIFF
--- a/lib/newark/app.rb
+++ b/lib/newark/app.rb
@@ -46,13 +46,6 @@ module Newark
 
     attr_reader :request, :response
 
-    def initialize(*)
-      super
-      @before_hooks = self.class.instance_variable_get(:@before_hooks)
-      @after_hooks  = self.class.instance_variable_get(:@after_hooks)
-      @routes       = self.class.instance_variable_get(:@routes)
-    end
-
     def call(env)
       dup._call(env)
     end
@@ -94,7 +87,7 @@ module Newark
     end
 
     def routes
-      @routes[@request.request_method]
+      self.class.instance_variable_get(:@routes)[@request.request_method]
     end
 
     def exec(action)
@@ -110,11 +103,11 @@ module Newark
     end
 
     def exec_before_hooks
-      exec_hooks @before_hooks
+      exec_hooks self.class.instance_variable_get(:@before_hooks)
     end
 
     def exec_after_hooks
-      exec_hooks @after_hooks
+      exec_hooks self.class.instance_variable_get(:@after_hooks)
     end
 
     def exec_hooks(hooks)


### PR DESCRIPTION
## Use Newark Application class variables directly

Currently, in a Newark app, three class variables `routes`,`before_hooks`, and `after_hooks` are used to store system-level variables. This PR is intended to leverage these class instance variables directly instead of creating a copy of these variables upon each request. The clear benefit is to presumably make it more efficient and smaller memory footprint.
