### PR TITLE
Add route id

### DIFF
--- a/lib/newark/route.rb
+++ b/lib/newark/route.rb
@@ -6,14 +6,15 @@ module Newark
     PATH_MATCHER  = /\*(?<path>.*)/.freeze
     PATH_SUB      = /\*.*/.freeze
 
-    attr_reader :handler
+    attr_reader :handler, :name
 
-    def initialize(path, constraints, handler)
+    def initialize(path, constraints, handler, name)
       fail ArgumentError, 'You must define a route handler' if handler.nil?
 
       @constraints = Constraint.load(constraints)
       @handler     = handler
       @path        = path_matcher(path)
+      @name        = name
     end
 
     def match?(request)

--- a/test/test_route_name.rb
+++ b/test/test_route_name.rb
@@ -1,0 +1,55 @@
+require 'helper'
+
+class RouteNameApp
+
+  include Newark
+
+  get '/route' do; end
+  get '/route_as_param', name: '/custom_route_name' do; end
+
+end
+
+class TestRouteName < MiniTest::Unit::TestCase
+
+  include Rack::Test::Methods
+
+  class EchoApp
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @app.call(env)
+      [200, {}, [ env['newark.route'].name ]]
+    end
+
+  end
+
+  def app
+    Rack::Lint.new(
+      EchoApp.new(
+        RouteNameApp.new
+      )
+    )
+  end
+
+  def test_route_name
+    get '/route'
+
+    assert_equal '/route', last_response.body
+  end
+
+  def test_route_name_as_option
+    get '/route_as_param'
+
+    assert_equal '/custom_route_name', last_response.body
+  end
+
+  def test_route_name_when_not_found
+    get '/i-dont-exist'
+
+    assert_equal '', last_response.body
+  end
+
+end


### PR DESCRIPTION
This PR adds the ability to assign a name to each route at route declaration. By default, the route name is the path itself.

``` ruby
get '/route1' #=> '/route1'
get '/route2', name: 'my route' #=> 'my route'
```

At route declaration, the `name` is added to the `Newark::Route` object, which is included in the `env`.

This is useful in a logging middleware where we would want to log specific paths our app is serving:

``` ruby
# middleware.rb
def call(env)
  @app.call(env).tap do
    puts env['newark.route'].name
  end
end
```

The default functionality of auto-naming routes is suitable for most use cases.  Routes specified as `/account/:account_id` will be named as such.  However, routes using regex ie `get(/\/regexp/)` are good candidates for renaming with the `:name` option.